### PR TITLE
fix: Updates the link for the list of open PRs

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -7,7 +7,7 @@
 - 🧱 Check out our [UI Library Storybook](https://infiniteobjects.github.io/ui/) to get an idea of some of our shared components
 - 🤓 Browse our MonoRepo [docs](https://infiniteobjects.github.io/stack/) and [repo](https://github.com/infiniteobjects/stack) to explore some projects and get familiar with useful utils 
 - 📖 Refer to our [growing Wiki](https://github.com/infiniteobjects/.github/wiki) for additional pointers
-- 📌 Make sure to pin [this list of Open PRs](https://github.com/pulls?q=is%3Aopen+is%3Apr+archived%3Afalse+user%3Ainfiniteobjects+-author%3Aapp%2Fdependabot) tracking all repos
+- 📌 Make sure to pin [this list of Open PRs](https://github.com/pulls?q=is%3Apr+is%3Aopen+user%3Ainfiniteobjects+-label%3Adependencies+-is%3Adraft) tracking all repos
 - ✅ [Asana](https://app.asana.com/0/home/1200740753180000) can help you see some of the other teams and what they're working on
 
 ### What is Web3?


### PR DESCRIPTION
## Summary of Changes
- Removes the `-author:app/dependabot` param to fix the bug where the list only shows the public PRs
- Adds the `draft:false` to filter out the draft PRs

## Links
- ~~Story~~
- ~~Sandbox~~

## How to test 
- Go to the IO [profile README](https://github.com/infiniteobjects/.github/blob/f3d559815dcb1ad79f6257c271474089ab4ade21/profile/README.md)
- Click the "list of open PRs" link
- The list should have all the (private and public) open PRs